### PR TITLE
HTML reader: JPO e-filing HTM → XML with inline decorations, chemistry, and non-patent literature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ output2
 ./images
 ./images
 .envrc
+var

--- a/scripts/run_test_parse.sh
+++ b/scripts/run_test_parse.sh
@@ -10,4 +10,4 @@ echo "Running test_parse.py with T=$T"
 echo "SRC1: $SRC1"
 echo "SRC2: $SRC2"
 echo "OUTPUT_DIR: $OUTPUT_DIR"
-uv run libefiling $SRC1 $SRC2 $OUTPUT_DIR
+uv run libefiling $SRC1 $SRC2 $OUTPUT_DIR --ocr-target other-images

--- a/src/libefiling/html/builder.py
+++ b/src/libefiling/html/builder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 from .parser import DescSection, HtmlPatent, Para
 
@@ -10,16 +11,69 @@ from .parser import DescSection, HtmlPatent, Para
 
 _PATCIT_LINE_RE = re.compile(r"^[　\s]*【特許文献([０-９\d]+)】(.+)")
 _FIGREF_LINE_RE = re.compile(r"^[　\s]*【図([０-９\d]+)】(.+)")
+_NPLCIT_LINE_RE = re.compile(r"^[　\s]*【非特許文献([０-９\d]+)】(.+)")
+_CHEM_HDR_RE = re.compile(r"^[　\s]*【化([０-９\d]+)】\s*$")
+_MATH_HDR_RE = re.compile(r"^[　\s]*【数([０-９\d]+)】\s*$")
+_TABLE_HDR_RE = re.compile(r"^[　\s]*【表([０-９\d]+)】\s*$")
+
+_IMG_RE = re.compile(r'<IMG\s[^>]*SRC="([^"]+)"[^>]*>', re.IGNORECASE)
+_WIDTH_RE = re.compile(r'WIDTH="(\d+)"', re.IGNORECASE)
+_HEIGHT_RE = re.compile(r'HEIGHT="(\d+)"', re.IGNORECASE)
 
 _DIGIT_MAP = str.maketrans("０１２３４５６７８９", "0123456789")
+
+# Inline HTML tags we convert to lowercase XML equivalents
+_INLINE_TAG_RE = re.compile(r'<(/?)(SUB|SUP|U)>', re.IGNORECASE)
+
+# Pattern to detect segment-ending punctuation (line is a "complete" segment)
+_ITEM_START_RE = re.compile(r'^[（(][Ａ-Ｚ０-９A-Za-z0-9]+[）)]')
+_MAX_LINE_LEN = 40  # JPO PRE-block word-wrap width (full-width chars)
+
+# Kind → file prefix map
+_KIND_PREFIX = {"chemistry": "C", "maths": "M", "tables": "T"}
 
 
 def _to_ascii(s: str) -> str:
     return s.translate(_DIGIT_MAP)
 
 
+_HTML_ENTITY_RE = re.compile(r'&(?:amp|lt|gt|apos|quot);')
+
+
+def _decode_html_entities(s: str) -> str:
+    """Decode basic HTML entities that JPO HTM files may contain."""
+    return s.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">").replace("&apos;", "'").replace("&quot;", '"')
+
+
 def _esc(s: str) -> str:
+    s = _decode_html_entities(s)
     return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _esc_inline(s: str) -> str:
+    """Convert inline HTML tags (SUB/SUP/U) to lowercase, escape remaining HTML chars."""
+    s = _INLINE_TAG_RE.sub(lambda m: f"<{m.group(1)}{m.group(2).lower()}>", s)
+    # Merge adjacent same-kind close+open pairs created by word-wrap splitting
+    # e.g. </sub><sub> → (merge), </sup><sup> → (merge)
+    s = re.sub(r'</(sub|sup|u)><\1>', '', s)
+    # Split on our known lowercase inline tags, escape text segments
+    parts = re.split(r'(</?(?:sub|sup|u)>)', s)
+    result = []
+    for part in parts:
+        if re.match(r'^</?(?:sub|sup|u)>$', part):
+            result.append(part)
+        else:
+            decoded = _decode_html_entities(part)
+            result.append(decoded.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+    return "".join(result)
+
+
+def _strip_tags(s: str) -> str:
+    return re.sub(r'<[^>]+>', '', s)
+
+
+def _px_to_mm(px: int) -> float:
+    return round(px * 25.4 / 96, 1)
 
 
 # ── section name → XML element mapping ───────────────────────────────────────
@@ -36,7 +90,6 @@ _SECTION_TAG: dict[str, str] = {
     "発明を実施するための最良の形態": "best-mode",
     "産業上の利用可能性": "industrial-applicability",
     "図面の簡単な説明": "description-of-drawings",
-    "実施例": "description-of-embodiments",
 }
 
 _CONTAINER_SECTIONS = {"発明の概要", "発明の開示"}
@@ -45,6 +98,7 @@ _CONTAINER_TAG_MAP = {
     "発明の概要": "summary-of-invention",
     "発明の開示": "disclosure",
 }
+# Sections that close the summary-of-invention/disclosure container
 _OUTSIDE_CONTAINER = {
     "発明を実施するための形態",
     "発明を実施するための最良の形態",
@@ -53,30 +107,129 @@ _OUTSIDE_CONTAINER = {
     "符号の説明",
     "実施例",
 }
+# Sections that open description-of-embodiments (or best-mode)
+_EMB_SECTIONS = {"発明を実施するための形態", "発明を実施するための最良の形態"}
+
+
+# ── inline content builder ────────────────────────────────────────────────────
+
+
+def _is_wordwrap(prev_raw: str, next_raw: str) -> bool:
+    """Return True if next_raw is a word-wrap continuation of prev_raw.
+
+    JPO HTM files wrap text at 40 full-width characters. A line that reaches
+    exactly this width was cut by the formatter and continues on the next line,
+    UNLESS the next line starts a new structural item (indented sentence or
+    numbered/lettered item like （Ａ）).
+    """
+    stripped_len = len(_strip_tags(prev_raw.rstrip("\r\n")))
+    if stripped_len < _MAX_LINE_LEN:
+        return False  # line ended naturally → not word-wrap
+    # max-width line; join unless next is a new structural item
+    if re.match(r"^[　]", next_raw):
+        return False  # new indented sentence
+    if _ITEM_START_RE.match(next_raw):
+        return False  # new numbered/lettered item
+    return True
+
+
+def _para_inline_xml(
+    lines: list[str],
+    img_counter: list[int],
+    image_map: dict[str, str],
+) -> str:
+    """Build the inner XML of a <p> or <claim-text> element from raw content lines.
+
+    Uses line-length-based word-wrap detection: lines hitting the 40-char maximum
+    are joined with the next line unless the next starts a new structural item.
+    """
+    # Step 1: group lines into typed items
+    # item = ('text', str) | ('block', kind, num, src, wi_mm, he_mm)
+    items: list = []
+
+    i = 0
+    while i < len(lines):
+        raw = lines[i].rstrip("\r\n")
+
+        # Check for block headers (【化N】 etc.)
+        block_kind: str | None = None
+        block_num: int = 0
+        for hdr_re, kind in (
+            (_CHEM_HDR_RE, "chemistry"),
+            (_MATH_HDR_RE, "maths"),
+            (_TABLE_HDR_RE, "tables"),
+        ):
+            if m := hdr_re.match(raw):
+                block_kind = kind
+                block_num = int(_to_ascii(m.group(1)))
+                break
+
+        if block_kind is not None:
+            # Look ahead for the IMG line
+            if i + 1 < len(lines) and (img_m := _IMG_RE.search(lines[i + 1])):
+                src = img_m.group(1)
+                img_line = lines[i + 1]
+                w_px = int(w_m.group(1)) if (w_m := _WIDTH_RE.search(img_line)) else 639
+                h_px = int(h_m.group(1)) if (h_m := _HEIGHT_RE.search(img_line)) else 100
+                wi = _px_to_mm(w_px)
+                he = _px_to_mm(h_px)
+                items.append(("block", block_kind, block_num, src, wi, he))
+                i += 2
+            else:
+                # No IMG tag following; skip the header line
+                i += 1
+            continue
+
+        # Regular text line – join with previous item if it was word-wrapped
+        # items store ('text', accumulated_text, last_raw_line) so we check
+        # the length of the LAST RAW LINE added, not the entire accumulated text.
+        if raw and items and items[-1][0] == "text":
+            _, prev_text, prev_last_raw = items[-1]
+            if _is_wordwrap(prev_last_raw, raw):
+                items[-1] = ("text", prev_text + raw, raw)
+                i += 1
+                continue
+
+        items.append(("text", raw, raw))
+        i += 1
+
+    # Step 2: generate XML from items
+    parts: list[str] = []
+    for idx, item in enumerate(items):
+        is_last = idx == len(items) - 1
+        if item[0] == "text":
+            text = item[1]
+            if not text or not text.strip():
+                # blank/space-only line
+                xml_text = " <br />" if not is_last else " "
+            else:
+                xml_text = _esc_inline(text)
+                if not is_last:
+                    xml_text += "<br />"
+            parts.append(xml_text)
+        else:
+            _, kind, num, src, wi, he = item
+            img_counter[0] += 1
+            n = img_counter[0]
+            prefix = _KIND_PREFIX[kind]
+            filename = f"JPOXMLDOC01-appb-{prefix}{n:06d}.tif"
+            image_map[src] = filename
+            img_tag = f'<img he="{he}" wi="{wi}" file="{filename}" img-format="tif" />'
+            parts.append(f'<{kind} num="{num}">\n{img_tag}\n</{kind}>')
+
+    return "\n".join(parts)
 
 
 # ── paragraph builders ────────────────────────────────────────────────────────
 
 
-def _join_para_lines(lines: list[str]) -> str:
-    """Join content lines into a single paragraph text.
-
-    Lines starting with 　 (full-width space) are segment starters;
-    other lines are continuations joined without separator.
-    For description <p> elements we emit one contiguous text block.
-    """
-    result = ""
-    for line in lines:
-        if line.startswith("　") or line.startswith(" "):
-            result += line
-        else:
-            result += line
-    return result
-
-
-def _para_tag(para: Para, extra_class: str = "normal") -> str:
-    text = _join_para_lines(para.content_lines)
-    return f'<p num="{para.num}">\n{_esc(text)}\n</p>'
+def _para_tag(
+    para: Para,
+    img_counter: list[int],
+    image_map: dict[str, str],
+) -> str:
+    content = _para_inline_xml(para.content_lines, img_counter, image_map)
+    return f'<p num="{para.num}">\n{content}\n</p>'
 
 
 def _patcit_para_tag(para: Para) -> str:
@@ -86,6 +239,29 @@ def _patcit_para_tag(para: Para) -> str:
             n = int(_to_ascii(m.group(1)))
             text = _esc(m.group(2).strip())
             lines_xml.append(f'<patcit num="{n}"><text>{text}</text></patcit>')
+    return f'<p num="{para.num}">\n' + "\n".join(lines_xml) + "\n</p>"
+
+
+def _nplcit_para_tag(para: Para) -> str:
+    lines_xml: list[str] = []
+    cur_num: int | None = None
+    cur_text = ""
+
+    def _flush_nplcit() -> None:
+        if cur_num is not None:
+            lines_xml.append(
+                f'<nplcit num="{cur_num}"><text>{_esc(cur_text.strip())}</text></nplcit>'
+            )
+
+    for ln in para.content_lines:
+        if m := _NPLCIT_LINE_RE.match(ln):
+            _flush_nplcit()
+            cur_num = int(_to_ascii(m.group(1)))
+            cur_text = m.group(2)
+        elif cur_num is not None:
+            cur_text += ln.rstrip("\r\n")
+
+    _flush_nplcit()
     return f'<p num="{para.num}">\n' + "\n".join(lines_xml) + "\n</p>"
 
 
@@ -100,7 +276,7 @@ def _figref_para_tag(para: Para) -> str:
             cur_figref = _to_ascii(m.group(1))
             cur_text = m.group(2)
         elif cur_figref is not None:
-            cur_text += ln  # continuation
+            cur_text += ln
     if cur_figref is not None:
         lines_xml.append(f'<figref num="{cur_figref}">{_esc(cur_text.strip())}</figref>')
     return f'<p num="{para.num}">\n' + "\n".join(lines_xml) + "\n</p>"
@@ -113,48 +289,66 @@ def _br_para_tag(para: Para) -> str:
 
 
 def _detect_para_type(section_name: str, para: Para) -> str:
-    """Return 'patcit', 'figref', 'br', or 'normal'."""
+    """Return 'patcit', 'nplcit', 'figref', 'br', or 'normal'."""
     if section_name == "特許文献":
         return "patcit"
+    if section_name == "非特許文献":
+        return "nplcit"
     if section_name == "図面の簡単な説明":
         return "figref"
     if section_name == "符号の説明":
         return "br"
-    # Check inline content
     for ln in para.content_lines:
         if _PATCIT_LINE_RE.match(ln):
             return "patcit"
     return "normal"
 
 
-def _emit_para(section_name: str, para: Para) -> str:
+def _emit_para(
+    section_name: str,
+    para: Para,
+    img_counter: list[int],
+    image_map: dict[str, str],
+) -> str:
     kind = _detect_para_type(section_name, para)
     if kind == "patcit":
         return _patcit_para_tag(para)
+    if kind == "nplcit":
+        return _nplcit_para_tag(para)
     if kind == "figref":
         return _figref_para_tag(para)
     if kind == "br":
         return _br_para_tag(para)
-    return _para_tag(para)
+    return _para_tag(para, img_counter, image_map)
 
 
 # ── appb.xml builder ──────────────────────────────────────────────────────────
 
 
-def build_appb_xml(doc: HtmlPatent) -> str:
+def build_appb_xml(doc: HtmlPatent) -> tuple[str, dict[str, str]]:
+    """Build JPOXMLDOC01-appb.xml content.
+
+    Returns (xml_string, image_map) where image_map maps original image
+    filenames (from HTML) to their new output filenames.
+    """
     out: list[str] = []
+    image_map: dict[str, str] = {}
+    img_counter: list[int] = [0]
+
     out.append("<?xml version='1.0' encoding='utf-8'?>")
     out.append(
         f'<application-body country="JP" dtd-version="{doc.dtd_version}" lang="ja" status="n">'
     )
     out.append("<description>")
 
-    # invention title
     title = _get_invention_title(doc)
     out.append(f"<invention-title>{_esc(title)}</invention-title>")
 
     container_tag: str | None = None
     in_citation = False
+    in_patent_lit = False
+    emb_tag: str | None = None        # open 'description-of-embodiments' or 'best-mode'
+    in_emb_example = False             # inside <embodiments-example>
 
     for sec in doc.desc_sections:
         name = sec.name
@@ -165,15 +359,33 @@ def build_appb_xml(doc: HtmlPatent) -> str:
         # ── citation list ────────────────────────────────────────────────────
         if name == "先行技術文献":
             in_citation = True
+            in_patent_lit = False
             out.append("<citation-list>")
-            out.append("<patent-literature>")
             continue
+
         if name == "特許文献" and in_citation:
+            if in_patent_lit:
+                out.append("</patent-literature>")
+            out.append("<patent-literature>")
+            in_patent_lit = True
             for p in sec.paragraphs:
-                out.append(_emit_para(name, p))
+                out.append(_emit_para(name, p, img_counter, image_map))
             continue
-        if in_citation and name not in ("特許文献",):
-            out.append("</patent-literature>")
+
+        if name == "非特許文献" and in_citation:
+            if in_patent_lit:
+                out.append("</patent-literature>")
+                in_patent_lit = False
+            out.append("<non-patent-literature>")
+            for p in sec.paragraphs:
+                out.append(_emit_para(name, p, img_counter, image_map))
+            out.append("</non-patent-literature>")
+            continue
+
+        if in_citation and name not in ("特許文献", "非特許文献"):
+            if in_patent_lit:
+                out.append("</patent-literature>")
+                in_patent_lit = False
             out.append("</citation-list>")
             in_citation = False
             # fall through to handle this section normally
@@ -189,7 +401,7 @@ def build_appb_xml(doc: HtmlPatent) -> str:
             tag = _SECTION_TAG[name]
             out.append(f"<{tag}>")
             for p in sec.paragraphs:
-                out.append(_emit_para(name, p))
+                out.append(_emit_para(name, p, img_counter, image_map))
             out.append(f"</{tag}>")
             continue
 
@@ -198,18 +410,45 @@ def build_appb_xml(doc: HtmlPatent) -> str:
             out.append(f"</{container_tag}>")
             container_tag = None
 
+        # ── description-of-embodiments / best-mode ───────────────────────────
+        if name in _EMB_SECTIONS:
+            tag = _SECTION_TAG[name]
+            emb_tag = tag
+            out.append(f"<{tag}>")
+            for p in sec.paragraphs:
+                out.append(_emit_para(name, p, img_counter, image_map))
+            # Don't close yet — 【実施例】 may follow
+            continue
+
+        # ── 実施例 → embodiments-example inside current emb_tag ──────────────
+        if name == "実施例":
+            if emb_tag and not in_emb_example:
+                out.append("<embodiments-example>")
+                in_emb_example = True
+            for p in sec.paragraphs:
+                out.append(_emit_para(name, p, img_counter, image_map))
+            continue
+
+        # ── close embodiments if still open ──────────────────────────────────
+        if emb_tag:
+            if in_emb_example:
+                out.append("</embodiments-example>")
+                in_emb_example = False
+            out.append(f"</{emb_tag}>")
+            emb_tag = None
+
         # ── 符号の説明 → <heading> ───────────────────────────────────────────
         if name == "符号の説明":
             out.append("<heading>符号の説明</heading>")
             for p in sec.paragraphs:
-                out.append(_emit_para(name, p))
+                out.append(_emit_para(name, p, img_counter, image_map))
             continue
 
         # ── description-of-drawings ─────────────────────────────────────────
         if name == "図面の簡単な説明":
             out.append("<description-of-drawings>")
             for p in sec.paragraphs:
-                out.append(_emit_para(name, p))
+                out.append(_emit_para(name, p, img_counter, image_map))
             out.append("</description-of-drawings>")
             continue
 
@@ -219,25 +458,34 @@ def build_appb_xml(doc: HtmlPatent) -> str:
             continue
         out.append(f"<{tag}>")
         for p in sec.paragraphs:
-            out.append(_emit_para(name, p))
+            out.append(_emit_para(name, p, img_counter, image_map))
         out.append(f"</{tag}>")
 
-    # close citation list if still open (shouldn't happen, but be safe)
+    # close any open blocks
     if in_citation:
-        out.append("</patent-literature>")
+        if in_patent_lit:
+            out.append("</patent-literature>")
         out.append("</citation-list>")
-    # close container if still open
     if container_tag:
         out.append(f"</{container_tag}>")
+    if emb_tag:
+        if in_emb_example:
+            out.append("</embodiments-example>")
+        out.append(f"</{emb_tag}>")
 
     out.append("</description>")
 
     # ── claims ───────────────────────────────────────────────────────────────
     out.append("<claims>")
-    for i, text in enumerate(doc.claim_texts, 1):
+    for i, raw_lines in enumerate(doc.claim_raw_lines, 1):
+        # strip trailing blank lines
+        trimmed = list(raw_lines)
+        while trimmed and not trimmed[-1].strip():
+            trimmed.pop()
         out.append(f'<claim num="{i}">')
         out.append("<claim-text>")
-        out.append(text)
+        content = _para_inline_xml(trimmed, img_counter, image_map)
+        out.append(content)
         out.append("</claim-text>")
         out.append("</claim>")
     out.append("</claims>")
@@ -245,26 +493,31 @@ def build_appb_xml(doc: HtmlPatent) -> str:
     # ── abstract ─────────────────────────────────────────────────────────────
     out.append("<abstract>")
     out.append('<p num="">')
-    for item in doc.abstract_items:
-        out.append(f"{_esc(item)}<br />")
-    out.append("<br />")
-    out.append("")
+    for idx, item in enumerate(doc.abstract_items):
+        is_last = idx == len(doc.abstract_items) - 1
+        suffix = "" if is_last else "<br />"
+        out.append(f"{_esc(item)}{suffix}")
     out.append("</p>")
     out.append("</abstract>")
 
     # ── drawings ─────────────────────────────────────────────────────────────
     out.append("<drawings>")
     for fig in doc.figures:
+        img_counter[0] += 1
+        n = img_counter[0]
+        ext = Path(fig.src).suffix.lower()
+        img_name = f"JPOXMLDOC01-appb-D{n:06d}{ext}"
+        image_map[fig.src] = img_name
+        wi = _px_to_mm(fig.width)
+        he = _px_to_mm(fig.height)
+        img_format = ext.lstrip(".")
         out.append(f'<figure num="{fig.num}">')
-        img_name = f"JPOXMLDOC01-appb-D{fig.num:06d}.gif"
-        out.append(
-            f'<img he="{fig.height}" wi="{fig.width}" file="{img_name}" img-format="gif" />'
-        )
+        out.append(f'<img he="{he}" wi="{wi}" file="{img_name}" img-format="{img_format}" />')
         out.append("</figure>")
     out.append("</drawings>")
 
     out.append("</application-body>")
-    return "\n".join(out) + "\n"
+    return "\n".join(out) + "\n", image_map
 
 
 def _get_invention_title(doc: HtmlPatent) -> str:

--- a/src/libefiling/html/builder.py
+++ b/src/libefiling/html/builder.py
@@ -1,0 +1,369 @@
+"""Build JPOXMLDOC01-appb.xml and JPOXMLDOC01-jpbibl.xml from HtmlPatent."""
+
+from __future__ import annotations
+
+import re
+
+from .parser import DescSection, HtmlPatent, Para
+
+# ── XML helpers ───────────────────────────────────────────────────────────────
+
+_PATCIT_LINE_RE = re.compile(r"^[　\s]*【特許文献([０-９\d]+)】(.+)")
+_FIGREF_LINE_RE = re.compile(r"^[　\s]*【図([０-９\d]+)】(.+)")
+
+_DIGIT_MAP = str.maketrans("０１２３４５６７８９", "0123456789")
+
+
+def _to_ascii(s: str) -> str:
+    return s.translate(_DIGIT_MAP)
+
+
+def _esc(s: str) -> str:
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+# ── section name → XML element mapping ───────────────────────────────────────
+
+_SECTION_TAG: dict[str, str] = {
+    "技術分野": "technical-field",
+    "背景技術": "background-art",
+    "summary-of-invention": "summary-of-invention",
+    "disclosure": "disclosure",
+    "発明が解決しようとする課題": "tech-problem",
+    "課題を解決するための手段": "tech-solution",
+    "発明の効果": "advantageous-effects",
+    "発明を実施するための形態": "description-of-embodiments",
+    "発明を実施するための最良の形態": "best-mode",
+    "産業上の利用可能性": "industrial-applicability",
+    "図面の簡単な説明": "description-of-drawings",
+    "実施例": "description-of-embodiments",
+}
+
+_CONTAINER_SECTIONS = {"発明の概要", "発明の開示"}
+_CONTAINER_CHILDREN = {"発明が解決しようとする課題", "課題を解決するための手段", "発明の効果"}
+_CONTAINER_TAG_MAP = {
+    "発明の概要": "summary-of-invention",
+    "発明の開示": "disclosure",
+}
+_OUTSIDE_CONTAINER = {
+    "発明を実施するための形態",
+    "発明を実施するための最良の形態",
+    "産業上の利用可能性",
+    "図面の簡単な説明",
+    "符号の説明",
+    "実施例",
+}
+
+
+# ── paragraph builders ────────────────────────────────────────────────────────
+
+
+def _join_para_lines(lines: list[str]) -> str:
+    """Join content lines into a single paragraph text.
+
+    Lines starting with 　 (full-width space) are segment starters;
+    other lines are continuations joined without separator.
+    For description <p> elements we emit one contiguous text block.
+    """
+    result = ""
+    for line in lines:
+        if line.startswith("　") or line.startswith(" "):
+            result += line
+        else:
+            result += line
+    return result
+
+
+def _para_tag(para: Para, extra_class: str = "normal") -> str:
+    text = _join_para_lines(para.content_lines)
+    return f'<p num="{para.num}">\n{_esc(text)}\n</p>'
+
+
+def _patcit_para_tag(para: Para) -> str:
+    lines_xml = []
+    for ln in para.content_lines:
+        if m := _PATCIT_LINE_RE.match(ln):
+            n = int(_to_ascii(m.group(1)))
+            text = _esc(m.group(2).strip())
+            lines_xml.append(f'<patcit num="{n}"><text>{text}</text></patcit>')
+    return f'<p num="{para.num}">\n' + "\n".join(lines_xml) + "\n</p>"
+
+
+def _figref_para_tag(para: Para) -> str:
+    lines_xml = []
+    cur_figref: str | None = None
+    cur_text = ""
+    for ln in para.content_lines:
+        if m := _FIGREF_LINE_RE.match(ln):
+            if cur_figref is not None:
+                lines_xml.append(f'<figref num="{cur_figref}">{_esc(cur_text.strip())}</figref>')
+            cur_figref = _to_ascii(m.group(1))
+            cur_text = m.group(2)
+        elif cur_figref is not None:
+            cur_text += ln  # continuation
+    if cur_figref is not None:
+        lines_xml.append(f'<figref num="{cur_figref}">{_esc(cur_text.strip())}</figref>')
+    return f'<p num="{para.num}">\n' + "\n".join(lines_xml) + "\n</p>"
+
+
+def _br_para_tag(para: Para) -> str:
+    """Paragraph with <br /> after each content line (for 符号の説明 etc.)."""
+    inner = "\n".join(f"{_esc(ln)}<br />" for ln in para.content_lines if ln)
+    return f'<p num="{para.num}">\n{inner}\n</p>'
+
+
+def _detect_para_type(section_name: str, para: Para) -> str:
+    """Return 'patcit', 'figref', 'br', or 'normal'."""
+    if section_name == "特許文献":
+        return "patcit"
+    if section_name == "図面の簡単な説明":
+        return "figref"
+    if section_name == "符号の説明":
+        return "br"
+    # Check inline content
+    for ln in para.content_lines:
+        if _PATCIT_LINE_RE.match(ln):
+            return "patcit"
+    return "normal"
+
+
+def _emit_para(section_name: str, para: Para) -> str:
+    kind = _detect_para_type(section_name, para)
+    if kind == "patcit":
+        return _patcit_para_tag(para)
+    if kind == "figref":
+        return _figref_para_tag(para)
+    if kind == "br":
+        return _br_para_tag(para)
+    return _para_tag(para)
+
+
+# ── appb.xml builder ──────────────────────────────────────────────────────────
+
+
+def build_appb_xml(doc: HtmlPatent) -> str:
+    out: list[str] = []
+    out.append("<?xml version='1.0' encoding='utf-8'?>")
+    out.append(
+        f'<application-body country="JP" dtd-version="{doc.dtd_version}" lang="ja" status="n">'
+    )
+    out.append("<description>")
+
+    # invention title
+    title = _get_invention_title(doc)
+    out.append(f"<invention-title>{_esc(title)}</invention-title>")
+
+    container_tag: str | None = None
+    in_citation = False
+
+    for sec in doc.desc_sections:
+        name = sec.name
+
+        if name == "発明の名称":
+            continue
+
+        # ── citation list ────────────────────────────────────────────────────
+        if name == "先行技術文献":
+            in_citation = True
+            out.append("<citation-list>")
+            out.append("<patent-literature>")
+            continue
+        if name == "特許文献" and in_citation:
+            for p in sec.paragraphs:
+                out.append(_emit_para(name, p))
+            continue
+        if in_citation and name not in ("特許文献",):
+            out.append("</patent-literature>")
+            out.append("</citation-list>")
+            in_citation = False
+            # fall through to handle this section normally
+
+        # ── container open ───────────────────────────────────────────────────
+        if name in _CONTAINER_SECTIONS:
+            container_tag = _CONTAINER_TAG_MAP[name]
+            out.append(f"<{container_tag}>")
+            continue
+
+        # ── container children ───────────────────────────────────────────────
+        if name in _CONTAINER_CHILDREN:
+            tag = _SECTION_TAG[name]
+            out.append(f"<{tag}>")
+            for p in sec.paragraphs:
+                out.append(_emit_para(name, p))
+            out.append(f"</{tag}>")
+            continue
+
+        # ── close container if open ──────────────────────────────────────────
+        if container_tag and name in _OUTSIDE_CONTAINER:
+            out.append(f"</{container_tag}>")
+            container_tag = None
+
+        # ── 符号の説明 → <heading> ───────────────────────────────────────────
+        if name == "符号の説明":
+            out.append("<heading>符号の説明</heading>")
+            for p in sec.paragraphs:
+                out.append(_emit_para(name, p))
+            continue
+
+        # ── description-of-drawings ─────────────────────────────────────────
+        if name == "図面の簡単な説明":
+            out.append("<description-of-drawings>")
+            for p in sec.paragraphs:
+                out.append(_emit_para(name, p))
+            out.append("</description-of-drawings>")
+            continue
+
+        # ── generic section ──────────────────────────────────────────────────
+        tag = _SECTION_TAG.get(name)
+        if tag is None:
+            continue
+        out.append(f"<{tag}>")
+        for p in sec.paragraphs:
+            out.append(_emit_para(name, p))
+        out.append(f"</{tag}>")
+
+    # close citation list if still open (shouldn't happen, but be safe)
+    if in_citation:
+        out.append("</patent-literature>")
+        out.append("</citation-list>")
+    # close container if still open
+    if container_tag:
+        out.append(f"</{container_tag}>")
+
+    out.append("</description>")
+
+    # ── claims ───────────────────────────────────────────────────────────────
+    out.append("<claims>")
+    for i, text in enumerate(doc.claim_texts, 1):
+        out.append(f'<claim num="{i}">')
+        out.append("<claim-text>")
+        out.append(text)
+        out.append("</claim-text>")
+        out.append("</claim>")
+    out.append("</claims>")
+
+    # ── abstract ─────────────────────────────────────────────────────────────
+    out.append("<abstract>")
+    out.append('<p num="">')
+    for item in doc.abstract_items:
+        out.append(f"{_esc(item)}<br />")
+    out.append("<br />")
+    out.append("")
+    out.append("</p>")
+    out.append("</abstract>")
+
+    # ── drawings ─────────────────────────────────────────────────────────────
+    out.append("<drawings>")
+    for fig in doc.figures:
+        out.append(f'<figure num="{fig.num}">')
+        img_name = f"JPOXMLDOC01-appb-D{fig.num:06d}.gif"
+        out.append(
+            f'<img he="{fig.height}" wi="{fig.width}" file="{img_name}" img-format="gif" />'
+        )
+        out.append("</figure>")
+    out.append("</drawings>")
+
+    out.append("</application-body>")
+    return "\n".join(out) + "\n"
+
+
+def _get_invention_title(doc: HtmlPatent) -> str:
+    for sec in doc.desc_sections:
+        if sec.name == "発明の名称" and sec.paragraphs:
+            return sec.paragraphs[0].content_lines[0] if sec.paragraphs[0].content_lines else ""
+    return ""
+
+
+# ── jpbibl.xml builder ────────────────────────────────────────────────────────
+
+
+def build_jpbibl_xml(doc: HtmlPatent) -> str:
+    out: list[str] = []
+    out.append("<?xml version='1.0' encoding='utf-8'?>")
+    out.append('<jp:pat-app-doc xmlns:jp="http://www.jpo.go.jp" lang="ja" dtd-version="1.0">')
+    out.append('<jp:application-a63 jp:kind-of-law="patent">')
+    out.append("<jp:document-code>A163</jp:document-code>")
+    out.append(f"<jp:file-reference-id>{_esc(doc.file_reference_id)}</jp:file-reference-id>")
+    out.append(f"<jp:addressed-to-person>{_esc(doc.addressed_to)}</jp:addressed-to-person>")
+
+    if doc.ipc_list:
+        out.append("<jp:ipc-article>")
+        for ipc in doc.ipc_list:
+            out.append(f"<jp:ipc>{_esc(ipc)}</jp:ipc>")
+        out.append("</jp:ipc-article>")
+
+    if doc.inventors:
+        out.append("<jp:inventors>")
+        for inv in doc.inventors:
+            out.append("<jp:inventor>")
+            out.append("<jp:addressbook>")
+            out.append(f"<jp:name>{_esc(inv.name)}</jp:name>")
+            if inv.address:
+                out.append("<jp:address>")
+                out.append(f"<jp:text>{_esc(inv.address)}</jp:text>")
+                out.append("</jp:address>")
+            out.append("</jp:addressbook>")
+            out.append("</jp:inventor>")
+        out.append("</jp:inventors>")
+
+    if doc.applicants:
+        out.append("<jp:applicants>")
+        for app in doc.applicants:
+            out.append("<jp:applicant>")
+            out.append("<jp:addressbook>")
+            out.append(f"<jp:name>{_esc(app.name)}</jp:name>")
+            out.append(f"<jp:registered-number>{_esc(app.registered_number)}</jp:registered-number>")
+            out.append("</jp:addressbook>")
+            out.append("</jp:applicant>")
+        out.append("</jp:applicants>")
+
+    if doc.agents:
+        out.append("<jp:agents>")
+        for ag in doc.agents:
+            out.append('<jp:agent jp:kind-of-agent="representative">')
+            out.append("<jp:addressbook>")
+            out.append(f"<jp:name>{_esc(ag.name)}</jp:name>")
+            out.append(f"<jp:registered-number>{_esc(ag.registered_number)}</jp:registered-number>")
+            out.append("</jp:addressbook>")
+            out.append("<jp:attorney />")
+            out.append("</jp:agent>")
+        out.append("</jp:agents>")
+
+    if doc.selected_agents:
+        out.append("<jp:attorney-change-article>")
+        for ag in doc.selected_agents:
+            out.append('<jp:agent jp:kind-of-agent="representative">')
+            out.append("<jp:addressbook>")
+            out.append(f"<jp:name>{_esc(ag.name)}</jp:name>")
+            out.append(f"<jp:registered-number>{_esc(ag.registered_number)}</jp:registered-number>")
+            out.append("</jp:addressbook>")
+            out.append("<jp:attorney />")
+            out.append("</jp:agent>")
+        out.append("</jp:attorney-change-article>")
+
+    if doc.law_of_industrial:
+        out.append(f"<jp:law-of-industrial-regenerate>{_esc(doc.law_of_industrial)}</jp:law-of-industrial-regenerate>")
+
+    out.append("<jp:charge-article>")
+    out.append("<jp:payment>")
+    out.append(f'<jp:fee amount="{doc.fee_amount}" currency="yen" />')
+    out.append(f'<jp:account number="{_esc(doc.fee_account)}" account-type="deposit" />')
+    out.append("</jp:payment>")
+    out.append("</jp:charge-article>")
+
+    if doc.submission_items or doc.power_of_attorney_ids:
+        out.append("<jp:submission-object-list-article>")
+        for item in doc.submission_items:
+            out.append("<jp:list-group>")
+            out.append(f"<jp:document-name>{_esc(item.doc_name)}</jp:document-name>")
+            out.append(f"<jp:number-of-object>{item.count}</jp:number-of-object>")
+            out.append("</jp:list-group>")
+        for pid in doc.power_of_attorney_ids:
+            out.append("<jp:list-group>")
+            out.append(f"<jp:general-power-of-attorney-id>{_esc(pid)}</jp:general-power-of-attorney-id>")
+            out.append("</jp:list-group>")
+        out.append("</jp:submission-object-list-article>")
+
+    out.append("</jp:application-a63>")
+    out.append("</jp:pat-app-doc>")
+    return "\n".join(out) + "\n"

--- a/src/libefiling/html/parser.py
+++ b/src/libefiling/html/parser.py
@@ -1,0 +1,406 @@
+"""Parse the structured text inside the PRE block of a JPO e-filing HTM file."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# ── character normalization ───────────────────────────────────────────────────
+
+_DIGIT_MAP = str.maketrans("０１２３４５６７８９", "0123456789")
+
+
+def _to_ascii(s: str) -> str:
+    return s.translate(_DIGIT_MAP)
+
+
+def _zfill4(s: str) -> str:
+    return _to_ascii(s).zfill(4)
+
+
+# ── regular expressions ───────────────────────────────────────────────────────
+
+# 　【０００１】  ← paragraph number (4-5 full-width digits, optional leading whitespace)
+_PARA_NUM_RE = re.compile(r"^[　\s]*【([０-９]{4,5})】\s*$")
+
+# 【書類名】テキスト
+_DOC_SECTION_RE = re.compile(r"^【書類名】(.+)")
+
+# 【発明の名称】テキスト  (inside 明細書 block, first field)
+_INVENTION_TITLE_RE = re.compile(r"^【発明の名称】(.+)")
+
+# 【請求項N】  N is ASCII or full-width digits
+_CLAIM_NUM_RE = re.compile(r"^【請求項([０-９\d]+)】\s*$")
+
+# 【図N】  in the drawings section (top-level, no leading whitespace)
+_FIGURE_HEADER_RE = re.compile(r"^【図([０-９\d]+)】\s*$")
+
+# <IMG SRC="..." WIDTH="..." HEIGHT="...">
+_IMG_RE = re.compile(
+    r'<IMG\s[^>]*SRC="([^"]+)"[^>]*>',
+    re.IGNORECASE,
+)
+_WIDTH_RE = re.compile(r'WIDTH="(\d+)"', re.IGNORECASE)
+_HEIGHT_RE = re.compile(r'HEIGHT="(\d+)"', re.IGNORECASE)
+
+# section header at column 0: 【something】  (no full-width-digit-only content)
+_SECTION_HDR_RE = re.compile(r"^【([^】]+)】")
+
+# inline patcit: 　　【特許文献N】テキスト
+_PATCIT_LINE_RE = re.compile(r"^[　\s]+【特許文献([０-９\d]+)】(.+)")
+
+# inline figref: 　　【図N】テキスト
+_FIGREF_LINE_RE = re.compile(r"^[　\s]+【図([０-９\d]+)】(.+)")
+
+
+# ── data model ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Para:
+    num: str  # ASCII digits, e.g. "0001"; "" for unnumbered
+    content_lines: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DescSection:
+    name: str
+    paragraphs: list[Para] = field(default_factory=list)
+
+
+@dataclass
+class Inventor:
+    name: str = ""
+    address: str = ""
+
+
+@dataclass
+class Applicant:
+    registered_number: str = ""
+    name: str = ""
+
+
+@dataclass
+class Agent:
+    registered_number: str = ""
+    name: str = ""
+
+
+@dataclass
+class SubmissionItem:
+    doc_name: str = ""
+    count: int = 1
+
+
+@dataclass
+class Figure:
+    num: int
+    src: str  # original filename of the GIF
+    width: int
+    height: int
+
+
+@dataclass
+class HtmlPatent:
+    # ── 特許願 ──────────────────────────────────────────────────────────────
+    file_reference_id: str = ""
+    addressed_to: str = ""
+    ipc_list: list[str] = field(default_factory=list)
+    inventors: list[Inventor] = field(default_factory=list)
+    applicants: list[Applicant] = field(default_factory=list)
+    agents: list[Agent] = field(default_factory=list)
+    selected_agents: list[Agent] = field(default_factory=list)
+    law_of_industrial: str = ""
+    fee_amount: int = 0
+    fee_account: str = ""
+    submission_items: list[SubmissionItem] = field(default_factory=list)
+    power_of_attorney_ids: list[str] = field(default_factory=list)
+
+    # ── 明細書 ──────────────────────────────────────────────────────────────
+    desc_sections: list[DescSection] = field(default_factory=list)
+
+    # ── 特許請求の範囲 ─────────────────────────────────────────────────────
+    # claim_texts[0] = claim 1 text (already joined), etc.
+    claim_texts: list[str] = field(default_factory=list)
+
+    # ── 要約書 ──────────────────────────────────────────────────────────────
+    # Each element is one "item" line in the abstract (joined continuations)
+    abstract_items: list[str] = field(default_factory=list)
+
+    # ── 図面 ────────────────────────────────────────────────────────────────
+    figures: list[Figure] = field(default_factory=list)
+
+    # ── derived ─────────────────────────────────────────────────────────────
+    dtd_version: str = "1.0"
+
+
+# ── public entry point ────────────────────────────────────────────────────────
+
+
+def parse(lines: list[str]) -> HtmlPatent:
+    doc = HtmlPatent()
+
+    for name, section_lines in _split_doc_sections(lines):
+        if name == "特許願":
+            _parse_application(section_lines, doc)
+        elif name == "明細書":
+            _parse_description(section_lines, doc)
+        elif name == "特許請求の範囲":
+            _parse_claims(section_lines, doc)
+        elif name == "要約書":
+            _parse_abstract(section_lines, doc)
+        elif name == "図面":
+            _parse_drawings(section_lines, doc)
+
+    # Determine DTD version from section names present
+    names = {s.name for s in doc.desc_sections}
+    if "発明の概要" in names or "先行技術文献" in names:
+        doc.dtd_version = "1.6"
+    else:
+        doc.dtd_version = "1.0"
+
+    return doc
+
+
+# ── section splitter ──────────────────────────────────────────────────────────
+
+
+def _split_doc_sections(lines: list[str]) -> list[tuple[str, list[str]]]:
+    sections: list[tuple[str, list[str]]] = []
+    current_name: str | None = None
+    current_lines: list[str] = []
+
+    for line in lines:
+        m = _DOC_SECTION_RE.match(line)
+        if m:
+            if current_name is not None:
+                sections.append((current_name, current_lines))
+            current_name = m.group(1).strip()
+            current_lines = []
+        elif current_name is not None:
+            current_lines.append(line)
+
+    if current_name is not None:
+        sections.append((current_name, current_lines))
+    return sections
+
+
+# ── 特許願 parser ─────────────────────────────────────────────────────────────
+
+
+def _parse_application(lines: list[str], doc: HtmlPatent) -> None:
+    i = 0
+    cur_inventor: Inventor | None = None
+    cur_applicant: Applicant | None = None
+    cur_agent: Agent | None = None
+    in_selected = False
+
+    while i < len(lines):
+        line = lines[i]
+
+        def _field(tag: str) -> re.Match | None:
+            return re.match(rf"^【{re.escape(tag)}】\s*(.*)", line)
+
+        def _sub_field(tag: str) -> re.Match | None:
+            return re.match(rf"^[　\s]+【{re.escape(tag)}】\s*(.*)", line)
+
+        if m := _field("整理番号"):
+            doc.file_reference_id = m.group(1).strip()
+        elif m := _field("あて先"):
+            doc.addressed_to = m.group(1).strip()
+        elif m := _field("国際特許分類"):
+            doc.ipc_list.append(m.group(1).rstrip("\r\n"))
+        elif _field("発明者"):
+            cur_inventor = Inventor()
+            doc.inventors.append(cur_inventor)
+            cur_applicant = cur_agent = None
+        elif _field("特許出願人"):
+            cur_applicant = Applicant()
+            doc.applicants.append(cur_applicant)
+            cur_inventor = cur_agent = None
+        elif _field("代理人"):
+            cur_agent = Agent()
+            doc.agents.append(cur_agent)
+            cur_inventor = cur_applicant = None
+            in_selected = False
+        elif _field("選任した代理人"):
+            cur_agent = Agent()
+            doc.selected_agents.append(cur_agent)
+            cur_inventor = cur_applicant = None
+            in_selected = True
+        elif m := _sub_field("住所又は居所"):
+            addr = m.group(1).strip()
+            i += 1
+            while i < len(lines) and lines[i] and not re.match(r"^[　\s]*【", lines[i]):
+                addr += lines[i].rstrip("\r\n")
+                i += 1
+            if cur_inventor:
+                cur_inventor.address = addr
+            continue
+        elif m := _sub_field("氏名"):
+            if cur_inventor:
+                cur_inventor.name = m.group(1).strip()
+        elif m := _sub_field("氏名又は名称"):
+            if cur_applicant:
+                cur_applicant.name = m.group(1).strip()
+            elif cur_agent:
+                cur_agent.name = m.group(1).strip()
+        elif m := _sub_field("識別番号"):
+            if cur_applicant:
+                cur_applicant.registered_number = m.group(1).strip()
+            elif cur_agent:
+                cur_agent.registered_number = m.group(1).strip()
+        elif m := _field("国等の委託研究の成果に係る記載事項"):
+            text = m.group(1).strip()
+            i += 1
+            while i < len(lines) and lines[i] and not re.match(r"^【", lines[i]):
+                text += lines[i].strip()
+                i += 1
+            doc.law_of_industrial = text
+            continue
+        elif m := _sub_field("予納台帳番号"):
+            doc.fee_account = m.group(1).strip()
+        elif m := _sub_field("納付金額"):
+            raw = m.group(1).strip().replace(",", "").replace("，", "").replace("円", "")
+            try:
+                doc.fee_amount = int(raw)
+            except ValueError:
+                pass
+        elif m := re.match(r"^[　\s]+【物件名】\s*(.+?)\s+(\d+)\s*$", line):
+            doc.submission_items.append(
+                SubmissionItem(doc_name=m.group(1).strip(), count=int(m.group(2)))
+            )
+        elif m := _sub_field("包括委任状番号"):
+            doc.power_of_attorney_ids.append(m.group(1).strip())
+
+        i += 1
+
+
+# ── 明細書 parser ─────────────────────────────────────────────────────────────
+
+
+def _parse_description(lines: list[str], doc: HtmlPatent) -> None:
+    cur_section: DescSection | None = None
+    cur_para: Para | None = None
+
+    for line in lines:
+        # paragraph number?
+        if m := _PARA_NUM_RE.match(line):
+            num = _zfill4(m.group(1))
+            cur_para = Para(num=num)
+            if cur_section is not None:
+                cur_section.paragraphs.append(cur_para)
+            continue
+
+        # section header at column 0?
+        if m := _SECTION_HDR_RE.match(line):
+            header = m.group(1)
+
+            if header.startswith("発明の名称"):
+                title = line[len("【発明の名称】"):].strip()
+                sec = DescSection(name="発明の名称")
+                sec.paragraphs.append(Para(num="", content_lines=[title]))
+                doc.desc_sections.append(sec)
+                cur_section = None
+                cur_para = None
+                continue
+
+            # Not a paragraph number, not 書類名 → subsection header
+            cur_section = DescSection(name=header)
+            doc.desc_sections.append(cur_section)
+            cur_para = None
+            continue
+
+        # content line
+        if cur_para is not None and line:
+            cur_para.content_lines.append(line)
+
+
+# ── 特許請求の範囲 parser ─────────────────────────────────────────────────────
+
+
+def _parse_claims(lines: list[str], doc: HtmlPatent) -> None:
+    cur_lines: list[str] = []
+    in_claim = False
+
+    def _flush():
+        if cur_lines:
+            doc.claim_texts.append(_join_claim_lines(cur_lines))
+
+    for line in lines:
+        if m := _CLAIM_NUM_RE.match(line):
+            _flush()
+            cur_lines = []
+            in_claim = True
+        elif in_claim:
+            cur_lines.append(line)
+
+    _flush()
+
+
+def _join_claim_lines(lines: list[str]) -> str:
+    """Join claim lines: lines starting with 　 are semantic segments joined by <br />;
+    lines without leading 　 are continuations joined directly."""
+    segments: list[str] = []
+    cur = ""
+    for line in lines:
+        if not line:
+            continue
+        if line.startswith("　") or line.startswith(" "):
+            if cur:
+                segments.append(cur)
+            cur = line
+        else:
+            cur += line  # continuation: join without separator
+    if cur:
+        segments.append(cur)
+
+    if len(segments) <= 1:
+        return segments[0] if segments else ""
+    return "<br />\n".join(segments)
+
+
+# ── 要約書 parser ─────────────────────────────────────────────────────────────
+
+
+def _parse_abstract(lines: list[str], doc: HtmlPatent) -> None:
+    """Each 【...】 line starts a new item; continuation lines are joined."""
+    cur_item: str | None = None
+
+    for line in lines:
+        if not line:
+            continue
+        if line.startswith("【"):
+            if cur_item is not None:
+                doc.abstract_items.append(cur_item)
+            cur_item = line
+        else:
+            if cur_item is not None:
+                cur_item += line  # join continuation
+            else:
+                cur_item = line
+
+    if cur_item is not None:
+        doc.abstract_items.append(cur_item)
+
+
+# ── 図面 parser ───────────────────────────────────────────────────────────────
+
+
+def _parse_drawings(lines: list[str], doc: HtmlPatent) -> None:
+    cur_num: int | None = None
+
+    for line in lines:
+        if m := _FIGURE_HEADER_RE.match(line):
+            cur_num = int(_to_ascii(m.group(1)))
+            continue
+
+        if cur_num is not None:
+            if img_m := _IMG_RE.search(line):
+                src = img_m.group(1)
+                w_m = _WIDTH_RE.search(line)
+                h_m = _HEIGHT_RE.search(line)
+                width = int(w_m.group(1)) if w_m else 0
+                height = int(h_m.group(1)) if h_m else 0
+                doc.figures.append(Figure(num=cur_num, src=src, width=width, height=height))
+                cur_num = None

--- a/src/libefiling/html/parser.py
+++ b/src/libefiling/html/parser.py
@@ -120,8 +120,8 @@ class HtmlPatent:
     desc_sections: list[DescSection] = field(default_factory=list)
 
     # ── 特許請求の範囲 ─────────────────────────────────────────────────────
-    # claim_texts[0] = claim 1 text (already joined), etc.
-    claim_texts: list[str] = field(default_factory=list)
+    # claim_raw_lines[0] = raw HTML lines for claim 1, etc.
+    claim_raw_lines: list[list[str]] = field(default_factory=list)
 
     # ── 要約書 ──────────────────────────────────────────────────────────────
     # Each element is one "item" line in the abstract (joined continuations)
@@ -325,7 +325,7 @@ def _parse_claims(lines: list[str], doc: HtmlPatent) -> None:
 
     def _flush():
         if cur_lines:
-            doc.claim_texts.append(_join_claim_lines(cur_lines))
+            doc.claim_raw_lines.append(list(cur_lines))
 
     for line in lines:
         if m := _CLAIM_NUM_RE.match(line):
@@ -336,28 +336,6 @@ def _parse_claims(lines: list[str], doc: HtmlPatent) -> None:
             cur_lines.append(line)
 
     _flush()
-
-
-def _join_claim_lines(lines: list[str]) -> str:
-    """Join claim lines: lines starting with 　 are semantic segments joined by <br />;
-    lines without leading 　 are continuations joined directly."""
-    segments: list[str] = []
-    cur = ""
-    for line in lines:
-        if not line:
-            continue
-        if line.startswith("　") or line.startswith(" "):
-            if cur:
-                segments.append(cur)
-            cur = line
-        else:
-            cur += line  # continuation: join without separator
-    if cur:
-        segments.append(cur)
-
-    if len(segments) <= 1:
-        return segments[0] if segments else ""
-    return "<br />\n".join(segments)
 
 
 # ── 要約書 parser ─────────────────────────────────────────────────────────────

--- a/src/libefiling/html/reader.py
+++ b/src/libefiling/html/reader.py
@@ -1,0 +1,21 @@
+import re
+from pathlib import Path
+
+
+def read_htm(path: str | Path) -> list[str]:
+    """Read a Shift-JIS encoded HTM file and return lines from the PRE block."""
+    data = Path(path).read_bytes()
+    text = data.decode("shift_jis", errors="replace")
+    m = re.search(r"<PRE>(.*?)</PRE>", text, re.DOTALL | re.IGNORECASE)
+    if m:
+        text = m.group(1)
+    return text.splitlines()
+
+
+def find_htm_file(directory: str | Path) -> Path:
+    """Find the single HTM file in a directory."""
+    d = Path(directory)
+    candidates = list(d.glob("*.HTM")) + list(d.glob("*.htm"))
+    if not candidates:
+        raise FileNotFoundError(f"No HTM file found in {directory}")
+    return candidates[0]

--- a/src/libefiling/parse.py
+++ b/src/libefiling/parse.py
@@ -1,11 +1,15 @@
 import os
 import re
+import shutil
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from pathlib import Path
 from typing import Iterable, Iterator, List
 
 from libefiling.archive.utils import generate_sha256
+from libefiling.html.builder import build_appb_xml, build_jpbibl_xml
+from libefiling.html.parser import parse as parse_html_text
+from libefiling.html.reader import find_htm_file, read_htm
 from libefiling.image.kind import OCR_TARGET, detect_image_kind
 from libefiling.image.mediatype import get_media_type
 from libefiling.manifest import (
@@ -16,6 +20,7 @@ from libefiling.manifest import (
     Manifest,
     OcrInfo,
     Paths,
+    Source,
     Sources,
     Stats,
     XmlFile,
@@ -279,6 +284,114 @@ def get_ocr_info(image: Path, ocr_dir: Path, lang: str) -> OcrInfo:
     )
     o.add_ocr_text(ocr_text)
     return o
+
+
+def parse_html(
+    src_html_dir: str,
+    src_procedure_path: str,
+    output_dir: str,
+    image_params: list[ImageConvertParam] | None = None,
+    ocr_target: List[OCR_TARGET] | None = None,
+    image_max_workers: int | None = None,
+) -> None:
+    """Parse a JPO e-filing HTM directory and generate XML + WebP outputs."""
+
+    src_dir = Path(src_html_dir)
+    if not src_dir.is_dir():
+        raise FileNotFoundError(f"Source HTML directory not found: {src_html_dir}")
+    if not Path(src_procedure_path).exists():
+        raise FileNotFoundError(f"Source procedure XML not found: {src_procedure_path}")
+
+    output_root = Path(output_dir)
+    p = Paths.create(output_root)
+
+    ### find and parse the HTM file
+    htm_path = find_htm_file(src_dir)
+    lines = read_htm(htm_path)
+    doc = parse_html_text(lines)
+
+    ### write appb.xml and jpbibl.xml to xml_dir
+    xml_files: list[XmlFile] = []
+    for filename, content in [
+        ("JPOXMLDOC01-appb.xml", build_appb_xml(doc)),
+        ("JPOXMLDOC01-jpbibl.xml", build_jpbibl_xml(doc)),
+    ]:
+        out_path = p.xml_dir / filename
+        out_path.write_text(content, encoding="utf-8")
+        xml_files.append(
+            XmlFile(
+                filename=filename,
+                sha256=generate_sha256(out_path),
+                encoding=EncodingInfo(detected="shift_jis", normalized_to="UTF-8"),
+                kind=detect_xml_kind(filename),
+            )
+        )
+
+    ### copy and rename GIF files to raw_dir as JPOXMLDOC01-appb-D000001.gif ...
+    for fig in doc.figures:
+        src_img = src_dir / fig.src
+        dst_name = f"JPOXMLDOC01-appb-D{fig.num:06d}.gif"
+        dst_img = p.raw_dir / dst_name
+        if src_img.exists():
+            shutil.copy2(src_img, dst_img)
+
+    ### copy procedure.xml (already UTF-8 for HTML input)
+    proc_xml_path = p.xml_dir / "procedure.xml"
+    shutil.copy2(src_procedure_path, proc_xml_path)
+    xml_files.append(
+        XmlFile(
+            filename=proc_xml_path.name,
+            encoding=EncodingInfo(detected=None, normalized_to="UTF-8"),
+            sha256=generate_sha256(proc_xml_path),
+            kind=detect_xml_kind(proc_xml_path.name),
+        )
+    )
+
+    ### guess language
+    lang = guess_language_by_filename(str(p.xml_dir))
+
+    params = image_params if image_params is not None else defaultImageParams
+
+    ### process images (GIFs in raw_dir)
+    gif_images = list(p.raw_dir.glob("*.gif", case_sensitive=False))
+    images = process_images(
+        gif_images,
+        p.images_dir,
+        p.ocr_dir,
+        params,
+        lang,
+        ocr_target,
+        max_workers=image_max_workers,
+    )
+
+    ### generate images-information.xml
+    image_info_xml_path = p.xml_dir / "images-information.xml"
+    ImageEntry.save_as_xml(images, image_info_xml_path)
+    xml_files.append(XmlFile.to_xml_file(image_info_xml_path, kind="images-information"))
+
+    ### generate sources.xml
+    archive_source = Source.create(htm_path)
+    procedure_source = Source.create(src_procedure_path)
+    document_code = doc.file_reference_id or "UNKNOWN"
+    sources = Sources(
+        document_code=document_code,
+        archive=archive_source,
+        procedure=procedure_source,
+    )
+    sources_xml_path = p.xml_dir / "sources.xml"
+    sources.save_as_xml(sources_xml_path)
+    xml_files.append(XmlFile.to_xml_file(sources_xml_path, kind="source"))
+
+    ### calc stats and generate manifest
+    stats = Stats.create(p)
+    manifest = Manifest.create(
+        sources,
+        xml_files,
+        images,
+        p.relative_to(p.root),
+        stats,
+    )
+    manifest.save_as_json(p.root / "manifest.json")
 
 
 def sanitize_text(text: str) -> str:

--- a/src/libefiling/parse.py
+++ b/src/libefiling/parse.py
@@ -312,8 +312,9 @@ def parse_html(
 
     ### write appb.xml and jpbibl.xml to xml_dir
     xml_files: list[XmlFile] = []
+    appb_content, image_map = build_appb_xml(doc)
     for filename, content in [
-        ("JPOXMLDOC01-appb.xml", build_appb_xml(doc)),
+        ("JPOXMLDOC01-appb.xml", appb_content),
         ("JPOXMLDOC01-jpbibl.xml", build_jpbibl_xml(doc)),
     ]:
         out_path = p.xml_dir / filename
@@ -327,10 +328,9 @@ def parse_html(
             )
         )
 
-    ### copy and rename GIF files to raw_dir as JPOXMLDOC01-appb-D000001.gif ...
-    for fig in doc.figures:
-        src_img = src_dir / fig.src
-        dst_name = f"JPOXMLDOC01-appb-D{fig.num:06d}.gif"
+    ### copy and rename all images (figures + inline chemistry/maths/tables)
+    for src_name, dst_name in image_map.items():
+        src_img = src_dir / src_name
         dst_img = p.raw_dir / dst_name
         if src_img.exists():
             shutil.copy2(src_img, dst_img)
@@ -352,8 +352,11 @@ def parse_html(
 
     params = image_params if image_params is not None else defaultImageParams
 
-    ### process images (GIFs in raw_dir)
-    gif_images = list(p.raw_dir.glob("*.gif", case_sensitive=False))
+    ### process images (all image files in raw_dir)
+    gif_images = [
+        f for f in p.raw_dir.iterdir()
+        if f.suffix.lower() in {".gif", ".jpg", ".jpeg", ".tif", ".tiff", ".png", ".webp"}
+    ]
     images = process_images(
         gif_images,
         p.images_dir,


### PR DESCRIPTION
## Summary

- JPO電子出願HTMファイル（Shift-JIS）をXMLに変換するHTML readerを実装
- インライン装飾（`<u>`, `<sub>`, `<sup>`）、化学式/数式/表ブロック、非特許文献に対応
- `【実施例】`を`<description-of-embodiments>`内の`<embodiments-example>`にネスト

## Changes

### `src/libefiling/html/parser.py` (new)
- `parse()`: HTMファイルの構造（特許願・明細書・請求項・要約書・図面）を解析
- `HtmlPatent`, `DescSection`, `Para`, `Figure` などのデータクラス
- `claim_raw_lines`: 請求項のHTML生行をそのまま保持（インライン処理のため）

### `src/libefiling/html/builder.py` (new)
- `build_appb_xml()`: `HtmlPatent` → `JPOXMLDOC01-appb.xml` + `image_map`
- `build_jpbibl_xml()`: `HtmlPatent` → `JPOXMLDOC01-jpbibl.xml`
- 行長40文字ベースのワードラップ検出で `<br />` を正確に挿入
- `<SUB>` タグが行をまたぐ場合の `</sub><sub>` マージ処理
- 画像寸法をピクセル→mm変換（`px * 25.4 / 96`）

### `src/libefiling/html/reader.py` (new)
- Shift-JIS HTMファイルの読み込み・PRE ブロック抽出

### `src/libefiling/parse.py`
- `parse_html()`: HTMディレクトリを入力としてXML・WebP・manifest を生成
- `image_map`（元ファイル名→出力ファイル名）で図・化学式・表の全画像をコピー

## Test plan
- [ ] `var/html-samples/h1` → `var/output1/` で動作確認済み
- [ ] `var/html-samples/h2` → `var/output2/` で動作確認済み
- [ ] `var/html-samples/h3` → `var/output3/` で動作確認済み（非特許文献・化学式）
- [ ] `var/html-samples/h4` → `var/output4/` で動作確認済み（表・数式・sub）

🤖 Generated with [Claude Code](https://claude.com/claude-code)